### PR TITLE
Fix layout closing tag in reset password page

### DIFF
--- a/src/pages/resetPassword.astro
+++ b/src/pages/resetPassword.astro
@@ -5,4 +5,4 @@ import PasswordReset from "../components/ResetPassword"
 
 <Layout>
     <PasswordReset client:load />
-<Layout/>
+</Layout>


### PR DESCRIPTION
## Summary
- close Layout properly in `resetPassword.astro`

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405e8e935c8320b957dfd25d3ceda4